### PR TITLE
Allow country id to be passed as an optional parameter

### DIFF
--- a/lib/gendered/guesser.rb
+++ b/lib/gendered/guesser.rb
@@ -1,12 +1,13 @@
 module Gendered
   class Guesser
 
-    attr_accessor :names
+    attr_accessor :names, :country_id
 
-    def initialize(values)
+    def initialize(values, country_id = nil)
       raise ArgumentError, "cannot be empty" if Array(values).empty?
 
       @names = Array(values)
+      @country_id = country_id
     end
 
     def guess!
@@ -34,11 +35,12 @@ module Gendered
 
     def url
       url = "http://api.genderize.io/?"
+      url += "country_id=#{country_id}&" if country_id
+
       name_queries = names.collect.with_index do |name, index|
         "name[#{index}]=#{CGI.escape(name.to_s)}"
       end
       url + name_queries.join("&")
     end
-
   end
 end

--- a/lib/gendered/name.rb
+++ b/lib/gendered/name.rb
@@ -16,8 +16,8 @@ module Gendered
       !!@gender
     end
 
-    def guess!
-      Guesser.new(self).guess!
+    def guess!(country_id = nil)
+      Guesser.new(self, country_id).guess!
       gender
     end
 

--- a/lib/gendered/name_list.rb
+++ b/lib/gendered/name_list.rb
@@ -13,9 +13,9 @@ module Gendered
       end
     end
 
-    def guess!
+    def guess!(country_id = nil)
       names.each_slice(100).each do |slice|
-        Guesser.new(slice).guess!
+        Guesser.new(slice).guess!(country_id)
       end
       names.collect(&:gender)
     end

--- a/spec/lib/gendered/guesser_spec.rb
+++ b/spec/lib/gendered/guesser_spec.rb
@@ -13,6 +13,11 @@ module Gendered
       expect(subject.names).to eq names
     end
 
+    it "is initialized with country id" do
+      guesser = Guesser.new(names, 'us')
+      expect(guesser.country_id).to eq 'us'
+    end
+
     it "creates the correct url" do
       expect(subject.url).to eq "http://api.genderize.io/?name[0]=Sean&name[1]=Theresa"
     end

--- a/spec/lib/gendered/name_list_spec.rb
+++ b/spec/lib/gendered/name_list_spec.rb
@@ -13,6 +13,13 @@ module Gendered
         expect(Guesser).to receive(:new).with(subject.names).and_return(guesser)
         subject.guess!
       end
+
+      it 'guesses correctly with country id' do
+        guesser = double(Guesser)
+        expect(guesser).to receive(:guess!).with('us')
+        expect(Guesser).to receive(:new).with(subject.names).and_return(guesser)
+        subject.guess!('us')
+      end
     end
     context "when the values are strings" do
       it "sets the names" do

--- a/spec/lib/gendered/name_spec.rb
+++ b/spec/lib/gendered/name_spec.rb
@@ -23,6 +23,12 @@ module Gendered
       it "returns the gender" do
         expect(subject.guess!).to eq :male
       end
+
+      it 'returns gender by country id' do
+        name = Gendered::Name.new('kim')
+        expect(name.guess!).to eq :female
+        expect(name.guess!('dk')).to eq :male
+      end
     end
 
     describe "#gender=" do


### PR DESCRIPTION
I added country id as an optional parameter to the Guesser. Since names instantiate a Guesser, I needed to pass the country id to `guess!`.