### PR TITLE
Use HTTPS instead of HTTP

### DIFF
--- a/lib/gendered/guesser.rb
+++ b/lib/gendered/guesser.rb
@@ -34,7 +34,7 @@ module Gendered
     end
 
     def url
-      url = "http://api.genderize.io/?"
+      url = "https://api.genderize.io/?"
       url += "country_id=#{country_id}&" if country_id
 
       name_queries = names.collect.with_index do |name, index|

--- a/lib/gendered/guesser.rb
+++ b/lib/gendered/guesser.rb
@@ -20,7 +20,12 @@ module Gendered
         names.collect do |name|
           name = Name.new(name) if name.is_a?(String)
 
-          guess = guesses.find { |g| g["name"] == name.value }
+          guess = case
+          when guesses.is_a?(Array)
+            guesses.find { |g| g["name"] == name.value }
+          else
+            guesses
+          end
 
           if guess["gender"]
             name.gender = guess["gender"].to_sym

--- a/lib/gendered/version.rb
+++ b/lib/gendered/version.rb
@@ -1,3 +1,3 @@
 module Gendered
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/lib/gendered/version.rb
+++ b/lib/gendered/version.rb
@@ -1,3 +1,3 @@
 module Gendered
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end

--- a/spec/lib/gendered/guesser_spec.rb
+++ b/spec/lib/gendered/guesser_spec.rb
@@ -19,7 +19,7 @@ module Gendered
     end
 
     it "creates the correct url" do
-      expect(subject.url).to eq "http://api.genderize.io/?name[0]=Sean&name[1]=Theresa"
+      expect(subject.url).to eq "https://api.genderize.io/?name[0]=Sean&name[1]=Theresa"
     end
 
     it "cannot be initialized with an empty array" do


### PR DESCRIPTION
It looks like Genderize.io is now requiring the use of HTTPS:

```
#<HTTP::Response/1.1 301 Moved Permanently #<HTTP::Headers
{"Date"=>"Mon, 23 Feb 2015 01:45:30 GMT", "Server"=>"Apache/2.4.7
(Ubuntu)", "Location"=>"https://api.genderize.io?name[0]=Frank",
"Content-Length"=>"327", "Content-Type"=>"text/html;
charset=iso-8859-1"}>>
```

and `Net::HTTP` is not handling the `301 Moved Permanently`.