### PR TITLE
Complete support for genderize.io API

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,20 @@ Or batch up a list of names (which sends only one request per hundred names to t
 > name_list["Sean"].gender
 => :male
 ```
+
+Options can be passed in too...
+```ruby
+options = { :apikey => "X123Y456", :country_id => "dk" }
+name = Gendered::Name.new("Sean")
+name.guess!(options)
+name_list = Gendered::NameList.new(["Kim", "Theresa"], options)
+```
+
+Or set globally, as defaults...
+```ruby
+Gendered.configure do |config|
+  config.apikey = "X123Y456"
+  config.language_id = "pt"
+  # ...
+end
+```

--- a/lib/gendered.rb
+++ b/lib/gendered.rb
@@ -1,4 +1,4 @@
-require 'bigdecimal'
+require "bigdecimal"
 
 require "http"
 
@@ -8,5 +8,22 @@ require "gendered/name_list"
 require "gendered/guesser"
 
 module Gendered
+  GenderedError = Class.new(StandardError)
 
+  class Config < Struct.new(:apikey, :country_id, :language_id, :connection)
+    def merge(other)
+      hash = respond_to?(:to_h) ? to_h : Hash[each_pair.to_a]
+      hash.merge!(other)
+      hash.reject! { |k,v| v.nil? }
+    end
+  end
+
+  def self.configure
+    raise ArgumentError, "configuration block required" unless block_given?
+    yield config
+  end
+
+  def self.config
+    @config ||= Config.new
+  end
 end

--- a/lib/gendered.rb
+++ b/lib/gendered.rb
@@ -9,6 +9,16 @@ require "gendered/guesser"
 
 module Gendered
   GenderedError = Class.new(StandardError)
+  class RateLimitError < GenderedError
+    attr_reader :limit, :remaining, :reset
+
+    def initialize(message, limit, remaining, reset)
+      super(message)
+      @limit = limit
+      @remaining = remaining
+      @reset = reset
+    end
+  end
 
   class Config < Struct.new(:apikey, :country_id, :language_id, :connection)
     def merge(other)

--- a/lib/gendered/guesser.rb
+++ b/lib/gendered/guesser.rb
@@ -1,22 +1,23 @@
+require "json"
+
 module Gendered
   class Guesser
 
-    attr_accessor :names, :country_id
+    attr_accessor :names, :options
 
-    def initialize(values, country_id = nil)
+    def initialize(values, options = {})
       raise ArgumentError, "cannot be empty" if Array(values).empty?
 
       @names = Array(values)
-      @country_id = country_id
+      @options = Gendered.config.merge(options || {})
+      @options[:connection] ||= {}
     end
 
     def guess!
-      response = HTTP.get(url)
+      response = request(@options[:connection])
+      guesses = parse(response.body)
       case response.code
       when 200
-
-        guesses = JSON.parse(response.body)
-
         names.collect do |name|
           name = Name.new(name) if name.is_a?(String)
 
@@ -35,17 +36,41 @@ module Gendered
 
           name
         end
+      else
+        message = sprintf "%s (%s)", guesses["message"], guesses["code"]
+        raise GenderedError.new(message)
       end
     end
 
+    # TODO: one can just call HTTP.get(url, :params => { ... })
     def url
       url = "https://api.genderize.io/?"
-      url += "country_id=#{country_id}&" if country_id
+      query = []
 
-      name_queries = names.collect.with_index do |name, index|
-        "name[#{index}]=#{CGI.escape(name.to_s)}"
+      [:country_id, :language_id, :apikey].each do |param|
+        next if @options[param].nil?
+        query << sprintf("%s=%s", param.to_s, CGI.escape(@options[param].to_s))
       end
-      url + name_queries.join("&")
+
+      names.each_with_index do |name, index|
+        query << sprintf("name[%s]=%s", index, CGI.escape(name.to_s))
+      end
+
+      url << query.join("&")
+    end
+
+    private
+
+    def request(options)
+      HTTP.get(url, options)
+    rescue => e
+      raise GenderedError, "request failed: #{e}"
+    end
+
+    def parse(response)
+      JSON.parse(response)
+    rescue JSON::ParserError => e
+      raise GenderedError, "cannot parse response JSON: #{e}"
     end
   end
 end

--- a/lib/gendered/guesser.rb
+++ b/lib/gendered/guesser.rb
@@ -29,8 +29,7 @@ module Gendered
       when 200
         create_names(body)
       else
-        message = sprintf "%s (%s)", body["message"], body["code"]
-        raise GenderedError.new(message)
+        raise GenderedError.new(body["error"])
       end
     end
 

--- a/lib/gendered/guesser.rb
+++ b/lib/gendered/guesser.rb
@@ -6,7 +6,7 @@ module Gendered
     USAGE_HEADERS = {
       "X-Rate-Limit-Limit" => :limit,
       "X-Rate-Limit-Remaining" => :remaining,
-      "X-Rate-Limit-Reset" => :reset
+      "X-Rate-Reset" => :reset
     }.freeze
 
     attr_reader :usage
@@ -28,6 +28,8 @@ module Gendered
       case response.code
       when 200
         create_names(body)
+      when 429
+        raise RateLimitError.new(body["error"], *@usage.values_at(:limit, :remaining, :reset))
       else
         raise GenderedError.new(body["error"])
       end

--- a/lib/gendered/name.rb
+++ b/lib/gendered/name.rb
@@ -1,6 +1,6 @@
 module Gendered
   class Name
-    VALID_GENDERS = %i(male female)
+    VALID_GENDERS = [:male, :female]
 
     attr_reader :value
 
@@ -16,8 +16,8 @@ module Gendered
       !!@gender
     end
 
-    def guess!(country_id = nil)
-      Guesser.new(self, country_id).guess!
+    def guess!(options = {})
+      Guesser.new(self, options).guess!
       gender
     end
 

--- a/lib/gendered/name_list.rb
+++ b/lib/gendered/name_list.rb
@@ -4,18 +4,20 @@ module Gendered
 
     attr_reader :names
 
-    def initialize(values)
+    def initialize(values, options = {})
       @names = Array(values).collect do |value|
         case value
         when String then Name.new(value)
         when Name then value
         end
       end
+
+      @options = options || {}
     end
 
-    def guess!(country_id = nil)
+    def guess!
       names.each_slice(100).each do |slice|
-        Guesser.new(slice).guess!(country_id)
+        Guesser.new(slice, @options).guess!
       end
       names.collect(&:gender)
     end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -1,0 +1,39 @@
+module Gendered
+  describe ".configure" do
+    let :settings do
+      {
+        :apikey      => "key",
+        :country_id  => "us",
+        :language_id => "en",
+        :connection  => { :foo => "bar" }
+      }
+    end
+
+    it "allows configuration via a block" do
+      Gendered.configure do |config|
+        settings.each do |name, value|
+          config[name] = value
+        end
+      end
+
+      settings.each do |name, value|
+        expect(Gendered.config[name]).to eq value
+      end
+    end
+  end
+
+  describe Config do
+    subject do
+      Gendered.config
+    end
+
+    describe "#merge" do
+      it "overrides the default config" do
+        subject[:country_id] = "us"
+        subject[:language_id] = "en"
+
+        expect(subject.merge(:language_id => "pt")).to eq(:country_id => "us", :language_id => "pt")
+      end
+    end
+  end
+end

--- a/spec/lib/gendered/guesser_spec.rb
+++ b/spec/lib/gendered/guesser_spec.rb
@@ -22,6 +22,16 @@ module Gendered
       expect{described_class.new([])}.to raise_error ArgumentError
     end
 
+    it "raises an error when over the rate limit" do
+      response = fake_response(:code => 429, :usage => { :limit => 1, :remaining => 0, :reset => 2 })
+      expect(subject).to receive(:request).and_return(response)
+      expect { subject.guess! }.to raise_error(RateLimitError) { |error|
+        expect(error.remaining).to eq 0
+        expect(error.limit).to eq 1
+        expect(error.reset).to eq 2
+      }
+    end
+
     describe "options" do
       [:country_id, :language_id, :apikey].each do |option|
         context "given the #{option} option" do

--- a/spec/lib/gendered/guesser_spec.rb
+++ b/spec/lib/gendered/guesser_spec.rb
@@ -55,6 +55,28 @@ module Gendered
       end
     end
 
+    describe "#usage" do
+      let :usage do
+        { :limit => nil, :remaining => nil, :reset => nil }
+      end
+
+      it "has no values until a request is made" do
+        expect(subject.usage).to eq usage
+      end
+
+      it "is populated after each request" do
+        usage.keys.each_with_index { |k, i| usage[k] = i }
+        expect(subject).to receive(:request).and_return(fake_response(:usage => usage))
+        subject.guess!
+        expect(subject.usage).to eq usage
+
+        usage.keys.each { |k| usage[k] += 1 }
+        expect(subject).to receive(:request).and_return(fake_response(:usage => usage))
+        subject.guess!
+        expect(subject.usage).to eq usage
+      end
+    end
+
     describe "#guess!" do
       it "returns a valid guesses hash" do
         names = subject.guess!

--- a/spec/lib/gendered/name_list_spec.rb
+++ b/spec/lib/gendered/name_list_spec.rb
@@ -3,24 +3,28 @@ module Gendered
     subject do
       described_class.new values
     end
+
     let :values do
-      ["Sean","Theresa"] * 50
+      ["Sean", "Theresa"] * 50
     end
+
     describe "#guess!" do
       it "guesses correctly" do
         guesser = double(Guesser)
         expect(guesser).to receive(:guess!)
-        expect(Guesser).to receive(:new).with(subject.names).and_return(guesser)
+        expect(Guesser).to receive(:new).with(subject.names, {}).and_return(guesser)
         subject.guess!
       end
 
-      it 'guesses correctly with country id' do
+      it "guesses correctly with country_id" do
+        subject = described_class.new(values, :country_id => "us")
         guesser = double(Guesser)
-        expect(guesser).to receive(:guess!).with('us')
-        expect(Guesser).to receive(:new).with(subject.names).and_return(guesser)
-        subject.guess!('us')
+        expect(guesser).to receive(:guess!)
+        expect(Guesser).to receive(:new).with(subject.names, :country_id => "us").and_return(guesser)
+        subject.guess!
       end
     end
+
     context "when the values are strings" do
       it "sets the names" do
         subject.names.each.with_index do |name, index|
@@ -28,10 +32,12 @@ module Gendered
         end
       end
     end
+
     context "when the values are names" do
       let :values do
-        [Name.new("Sean"),Name.new("Theresa")]
+        [Name.new("Sean"), Name.new("Theresa")]
       end
+
       it "sets the names" do
         expect(subject.names).to eq values
       end

--- a/spec/lib/gendered/name_spec.rb
+++ b/spec/lib/gendered/name_spec.rb
@@ -20,14 +20,29 @@ module Gendered
     end
 
     describe "guess!" do
+      it "sets the gender" do
+        subject.guess!
+        expect(subject.gender).to eq :male
+      end
+
+      it "sets the probability" do
+        subject.guess!
+        expect(subject.probability).to be_a BigDecimal
+      end
+
+      it "sets the sample size" do
+        subject.guess!
+        expect(subject.sample_size).to be_a Integer
+      end
+
       it "returns the gender" do
         expect(subject.guess!).to eq :male
       end
 
-      it 'returns gender by country id' do
-        name = Gendered::Name.new('kim')
+      it "returns gender by country id" do
+        name = Gendered::Name.new("kim")
         expect(name.guess!).to eq :female
-        expect(name.guess!('dk')).to eq :male
+        expect(name.guess!(:country_id => "dk")).to eq :male
       end
     end
 
@@ -38,6 +53,7 @@ module Gendered
           expect(subject.gender).to eq value
         end
       end
+
       it "raises an argument error if the gender is set to something invalid" do
         %w(eunich).each do |value|
           expect{subject.gender = value}.to raise_error(ArgumentError)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,4 +6,23 @@ RSpec.configure do |config|
       Gendered.config[name] = nil
     end
   end
+
+  config.include Module.new {
+    SUCCESS_RESPONSE = {
+      :count => 100,
+      :gender => "male",
+      :name => "Sean",
+      :probability => 1.0
+    }
+
+    FAILURE_RESPONSE = {
+      :error => "Some thang went wrong"
+    }
+
+    def fake_response(options = {})
+      code = options[:code] || 200
+      body = (code == 200 ? SUCCESS_RESPONSE : ERROR_RESPONSE).merge(options[:body] || {})
+      double(:code => code, :body => JSON.dump(body))
+    end
+  }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ RSpec.configure do |config|
 
     def fake_response(options = {})
       code = options[:code] || 200
-      body = (code == 200 ? SUCCESS_RESPONSE : ERROR_RESPONSE).merge(options[:body] || {})
+      body = (code == 200 ? SUCCESS_RESPONSE : FAILURE_RESPONSE).merge(options[:body] || {})
 
       headers = {}
       usage = options[:usage] || {}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 require "gendered"
 
 RSpec.configure do |config|
-
+  config.after :each do
+    Gendered.config.members.each do |name|
+      Gendered.config[name] = nil
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,18 @@ RSpec.configure do |config|
     def fake_response(options = {})
       code = options[:code] || 200
       body = (code == 200 ? SUCCESS_RESPONSE : ERROR_RESPONSE).merge(options[:body] || {})
-      double(:code => code, :body => JSON.dump(body))
+
+      headers = {}
+      usage = options[:usage] || {}
+
+      Gendered::Guesser::USAGE_HEADERS.each do |header, key|
+        headers[header] = usage.include?(key) ? usage[key] : header.object_id
+      end
+
+      response = double(:code => code, :body => JSON.dump(body))
+      allow(response).to receive(:[]) { |name| headers[name] }
+
+      response
     end
   }
 end


### PR DESCRIPTION
This fixes #5 -which was broken by fdb5274483e238347faf4a956313efe40f5c546d- and, in some part, addresses #2 & #6. It also modifies (i.e. breaks) various calls so that they accept a `Hash` instead of a just `country_id`.

To summarize:

1. `:country_id`, `:language_id`, `:apikey`, and `:connection` are now accepted as options.
`:connection's` value will be passed to the http.rb library

2. Configuration can be done globally via `Gendered.config` or
`Gendered.configure { |cfg| ... }`

3. Request/response related errors will result in a `GenderedError`
exceptions being raised

4. Support for rubies < 2.1, namely JRuby, by removing `%i()`

Some other things to consider changing:

## Inconsistent Return Values on `Name`

`#probability` and `#sample_size` return `:unknown` if they have not been guessed, and `BigDecimal` if they have been. These should return `0` or `nil` of they cannot be guessed.

[Their setters only allow `BigDecimal`](https://github.com/sshaw/gendered/blob/v0.0.7/lib/gendered/name.rb#L26) (though why would one want to set? Shouldn't these be readonly?). 

If  not guessed `#male?` and `#female?` return `:not_guessed`. I think it makes more sense for them to always return a boolean. If it's not guessed then it's neither male nor female, so these should return `false`. 

Consistency is important, but the current behavior can lead to errors:

```ruby
name = Gendered::Name.new("Mac Dre")
name.guess!
if name.female?
  # do some thangz
end
```


## Per Request Name Limit

The API docs say that [the limit is 10 names per request](https://store.genderize.io/documentation#multipleUsage), but [the code sends 100 at a time](https://github.com/barelyknown/gendered/blob/v0.0.7/lib/gendered/name_list.rb#L17). Are the docs wrong?


