### PR TITLE
Fix Requests to Work With Later Versions of The Ruby HTTP Gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Gendered
 
-**THIS LIBRARY IS STILL IN DEVELOPMENT.**
-
 Guess the gender of names with the help of the [genderize.io](http://genderize.io).
 
 ```bash

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,10 @@
 require "bundler/gem_tasks"
 
+begin
+  require "rspec/core/rake_task"
+
+  RSpec::Core::RakeTask.new(:spec)
+
+  task :default => :spec
+rescue LoadError
+end

--- a/gendered.gemspec
+++ b/gendered.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "http", ">= 0.6.2"
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/gendered/guesser.rb
+++ b/lib/gendered/guesser.rb
@@ -65,7 +65,7 @@ module Gendered
       options = {}
       options[:params] = @options.reject { |k, v| k == :connection || v.nil? }
       options[:params]["name[]"] = @names.map(&:to_s)
-      options[:connection] = @options[:connection] unless @options[:connection].empty?
+      options.merge!(@options[:connection]) unless @options[:connection].empty?
       options
     end
 

--- a/lib/gendered/guesser.rb
+++ b/lib/gendered/guesser.rb
@@ -23,6 +23,11 @@ module Gendered
 
     def guess!
       response = request(request_options)
+
+      if response["content-type"] !~ %r{\Aapplication/json\b}
+        raise GenderedError.new("received a non-JSON response with status #{response.code}: #{response.body}")
+      end
+
       update_usage(response)
       body = parse(response.body)
       case response.code

--- a/lib/gendered/guesser.rb
+++ b/lib/gendered/guesser.rb
@@ -64,7 +64,7 @@ module Gendered
     def request_options
       options = {}
       options[:params] = @options.reject { |k, v| k == :connection || v.nil? }
-      options[:params]["name[]"] = @names
+      options[:params]["name[]"] = @names.map(&:to_s)
       options[:connection] = @options[:connection] unless @options[:connection].empty?
       options
     end

--- a/spec/lib/gendered/guesser_spec.rb
+++ b/spec/lib/gendered/guesser_spec.rb
@@ -94,26 +94,33 @@ module Gendered
           expect(name).to be_a Name
         end
       end
-    end
 
-    context "with the name Evat" do
-      let :names do
-        ["Evat"]
+      context "when the response's content type is not application/json" do
+        it "raises an error" do
+          expect(subject).to receive(:request).and_return(fake_response(:content_type => "text/html"))
+          expect { subject.guess! }.to raise_error(Gendered::GenderedError, /received a non-JSON response/)
+        end
       end
 
-      it "does not error" do
-        expect{ subject.guess! }.to_not raise_error
-      end
-    end
+      context "with the name Evat" do
+        let :names do
+          ["Evat"]
+        end
 
-    context "with multiple names that are the same" do
-      let :names do
-        ["Sean","Sean"]
+        it "does not error" do
+          expect{ subject.guess! }.to_not raise_error
+        end
       end
 
-      it "guesses them both" do
-        guesses = subject.guess!
-        expect(guesses.collect(&:gender).uniq.size).to eq 1
+      context "with multiple names that are the same" do
+        let :names do
+          ["Sean","Sean"]
+        end
+
+        it "guesses them both" do
+          guesses = subject.guess!
+          expect(guesses.collect(&:gender).uniq.size).to eq 1
+        end
       end
     end
 

--- a/spec/lib/gendered/guesser_spec.rb
+++ b/spec/lib/gendered/guesser_spec.rb
@@ -58,7 +58,7 @@ module Gendered
         end
 
         it "is passed to the connection" do
-          params = hash_including(:connection => { :foo => "bar" })
+          params = hash_including(:foo => "bar")
           expect(subject).to receive(:request).with(params).and_return(fake_response)
           subject.guess!
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,15 @@ RSpec.configure do |config|
         headers[header] = usage.include?(key) ? usage[key] : header.object_id
       end
 
-      response = double(:code => code, :body => JSON.dump(body))
+      # Must use "content-type" as that's what code checks :( But HTTP lib is case insensitive.
+      if options.include?(:content_type)
+        headers["content-type"] =  options[:content_type]
+        response = double(:code => code, :body => body.to_s)
+      else
+        headers["content-type"] = "application/json; charset=utf-8"
+        response = double(:code => code, :body => JSON.dump(body))
+      end
+
       allow(response).to receive(:[]) { |name| headers[name] }
 
       response


### PR DESCRIPTION
Earlier versions of HTTP did the conversion this but this is no longer
the case.


Also removed the warning from the README since the code has not been updated since my last commits (2015) and I've been using it in production since then (though in the process of upgrading the app to Rails 5 and Ruby 2.5 😏 and found this issue). 

 